### PR TITLE
Improve tag filter experience on post list

### DIFF
--- a/src/app/journal/post-list/post-list.component.html
+++ b/src/app/journal/post-list/post-list.component.html
@@ -1,4 +1,13 @@
 <div class="container">
+  <div *ngIf="tag" id="tag-info" class="breadcrumbs">
+    Viewing posts tagged
+    <a class="clear-tag" routerLink="/journal" title="Remove tag filter">
+      <span data-tag>{{ tag }}</span>
+      <i class="fad fa-xs fa-fw fa-times close-icon" aria-hidden="true"></i>
+      <span class="sr-only">Remove tag filter</span>
+    </a>
+  </div>
+
   <ng-container *ngIf="postData$ | async as postData; else journalLoadState">
     <ng-container *ngIf="postData.posts.length === 0">
       <ng-container *ngTemplateOutlet="noPosts"></ng-container>
@@ -10,8 +19,6 @@
       [titleLink]="'../../post/' + post.slug"
       [attr.data-post]="post.postId"
     ></jblog-post>
-
-    <!-- posts  | arraySort: 'date' | arrayReverse -->
 
     <div class="text-center">
       <jblog-pagination

--- a/src/app/journal/post-list/post-list.component.scss
+++ b/src/app/journal/post-list/post-list.component.scss
@@ -1,0 +1,15 @@
+#tag-info .clear-tag {
+  padding: 2px 4px;
+  border: 1px solid var(--color-tag-border);
+  border-radius: var(--border-radius-default);
+  background: var(--color-tag-background);
+  color: var(--color-default-foreground);
+  text-decoration: none;
+  transition: 0.2s color, 0.2s border-color, 0.2s background-color;
+
+  &:hover {
+    border-color: var(--color-tag-hover-border);
+    background: var(--color-tag-hover-background);
+    color: var(--color-tag-hover-foreground);
+  }
+}

--- a/src/app/journal/post-list/post-list.component.spec.ts
+++ b/src/app/journal/post-list/post-list.component.spec.ts
@@ -40,6 +40,10 @@ class PostListPageObject extends PageObjectBase<PostListComponent> {
   public get pagination(): PaginationComponent {
     return this.selectDebug(By.css('jblog-pagination')).componentInstance;
   }
+
+  public get tagName(): HTMLSpanElement {
+    return this.select('[data-tag]');
+  }
 }
 
 describe('Post List Component', () => {
@@ -136,6 +140,23 @@ describe('Post List Component', () => {
           Times.once()
         );
         expect().nothing();
+        done();
+      });
+    });
+  });
+
+  describe('Tag filter behaviour', () => {
+    it('should not have tag information if no tag specified', () => {
+      expect(pageObject.tagName).toBeFalsy();
+    });
+
+    it('should provide tag info and page number when tag set', done => {
+      const mockTag = 'mock-tag';
+      paramsSubject.next({ page: mockPostData.page, tag: mockTag });
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        expect(pageObject.tagName.textContent).toBe(mockTag);
         done();
       });
     });

--- a/src/app/journal/post-list/post-list.component.ts
+++ b/src/app/journal/post-list/post-list.component.ts
@@ -10,7 +10,8 @@ import { JournalFacade } from '../state/journal.facade';
 
 @Component({
   selector: 'jblog-post-list',
-  templateUrl: './post-list.component.html'
+  templateUrl: './post-list.component.html',
+  styleUrls: ['./post-list.component.scss']
 })
 export class PostListComponent implements OnInit {
   public postData$: Observable<PostDataWrapper>;

--- a/src/app/journal/post-single/post-single.component.html
+++ b/src/app/journal/post-single/post-single.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <ng-container *ngIf="postData$ | async as postData; else loadState">
-    <nav id="breadcrumbs">
+    <nav id="breadcrumbs" class="breadcrumbs">
       <a routerLink="../.." data-back-button>Journal</a>
       <i class="spacer fad fa-angle-double-right" aria-hidden="true"></i>
       <span>{{ postData.title }}</span>
@@ -15,7 +15,7 @@
 
 <ng-template #loadState>
   <div *ngIf="loading$ | async; else noPosts" data-loading-posts>
-    <nav id="breadcrumbs">
+    <nav id="breadcrumbs" class="breadcrumbs">
       <a routerLink="../.." data-back-button>Journal</a>
       <i class="spacer fad fa-angle-double-right" aria-hidden="true"></i>
       <span>…</span>

--- a/src/app/journal/post-single/post-single.component.ts
+++ b/src/app/journal/post-single/post-single.component.ts
@@ -10,8 +10,7 @@ import { JournalFacade } from '../state/journal.facade';
 
 @Component({
   selector: 'jblog-post-single',
-  templateUrl: './post-single.component.html',
-  styleUrls: ['./post-single.component.scss']
+  templateUrl: './post-single.component.html'
 })
 export class PostSingleComponent implements OnInit {
   public postData$: Observable<PostData>;

--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges
-} from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 /**
  * An interface which can be used by a class to encapsulate a pagination segment.
@@ -68,7 +62,7 @@ export class PaginationComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Called when the component is initialized. Uased to generate
+   * Called when the component is initialized. Used to generate
    * {@link PaginationSegment}s.
    */
   ngOnInit() {
@@ -80,8 +74,8 @@ export class PaginationComponent implements OnInit, OnChanges {
    * {@link PaginationSegment}s.
    */
   ngOnChanges(changes: SimpleChanges) {
-    // Only update the pagination links if the page has changed
-    if (!changes['currentPage']) {
+    // Don't regenerate segments when the change is due to generating segments
+    if (changes['segments']) {
       return;
     }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,7 @@
 @import 'global/common-values';
 
 @import 'global/components/articles';
+@import 'global/components/breadcrumbs';
 @import 'global/components/buttons';
 @import 'global/components/cards';
 @import 'global/components/forms';

--- a/src/theme/global/components/_breadcrumbs.scss
+++ b/src/theme/global/components/_breadcrumbs.scss
@@ -1,4 +1,4 @@
-#breadcrumbs {
+.breadcrumbs {
   margin-bottom: 10px;
   color: var(--color-secondary-text);
 


### PR DESCRIPTION
Changes:
- Ensures that it's possible to remove the tag filter without manually editing the URL
- Fixes the pagination getting pages cached when tags changed - fixes #19 