### PR TITLE
Style fixes for single post and page header

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,37 +1,41 @@
 <header id="page-header">
-  <nav id="menu" class="container">
-    <a class="pane left home-link" [routerLink]="['/']">
-      <svg class="icon"><use xlink:href="#sitesheet-logo" /></svg>
-    </a>
-    <div class="pane central">
-      <ul class="links">
-        <li>
-          <a
-            class="hide-when-small"
-            [routerLink]="['/']"
-            routerLinkActive="active"
-            [routerLinkActiveOptions]="{ exact: true }"
-            >portfolio</a
-          >
-        </li>
-        <li>
-          <a [routerLink]="['/about']" routerLinkActive="active">about</a>
-        </li>
-        <li><a [routerLink]="['/art']" routerLinkActive="active">art</a></li>
-        <li>
-          <a [routerLink]="['/projects/code']" routerLinkActive="active"
-            >projects</a
-          >
-        </li>
-        <li>
-          <a [routerLink]="['/journal']" routerLinkActive="active">posts</a>
-        </li>
-      </ul>
-    </div>
-    <div class="pane right">
-      <jblog-user-menu></jblog-user-menu>
-    </div>
-  </nav>
+  <div id="sticky-menu">
+    <nav id="menu" class="container">
+      <div class="pane left">
+        <a class="home-link" [routerLink]="['/']">
+          <svg class="icon"><use xlink:href="#sitesheet-logo" /></svg>
+        </a>
+      </div>
+      <div class="pane central">
+        <ul class="links">
+          <li>
+            <a
+              class="hide-when-small"
+              [routerLink]="['/']"
+              routerLinkActive="active"
+              [routerLinkActiveOptions]="{ exact: true }"
+              >portfolio</a
+            >
+          </li>
+          <li>
+            <a [routerLink]="['/about']" routerLinkActive="active">about</a>
+          </li>
+          <li><a [routerLink]="['/art']" routerLinkActive="active">art</a></li>
+          <li>
+            <a [routerLink]="['/projects/code']" routerLinkActive="active"
+              >projects</a
+            >
+          </li>
+          <li>
+            <a [routerLink]="['/journal']" routerLinkActive="active">posts</a>
+          </li>
+        </ul>
+      </div>
+      <div class="pane right">
+        <jblog-user-menu></jblog-user-menu>
+      </div>
+    </nav>
+  </div>
 </header>
 <main
   id="page-content"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,13 +1,24 @@
 @import '_variables';
 
 #page-header,
-#menu {
+#sticky-menu {
   margin: var(--margin-page-header);
   height: var(--height-page-header);
 }
 
 #page-header {
   background-color: var(--color-container-background);
+}
+
+#sticky-menu {
+  width: 100%;
+  position: fixed;
+  justify-content: space-evenly;
+  z-index: 10;
+  border-top: 4px solid var(--color-page-flair);
+  background-color: var(--color-overlay-background);
+  box-shadow: var(--box-shadow-page-header) var(--color-default-shadow);
+  backdrop-filter: var(--value-overlay-filter);
 }
 
 #menu,
@@ -18,14 +29,7 @@
 }
 
 #menu {
-  width: 100%;
-  position: fixed;
-  justify-content: space-evenly;
-  z-index: 10;
-  border-top: 4px solid var(--color-page-flair);
-  background-color: var(--color-overlay-background);
-  box-shadow: var(--box-shadow-page-header) var(--color-default-shadow);
-  backdrop-filter: var(--value-overlay-filter);
+  height: 100%;
 
   a {
     color: var(--color-navigation-links-foreground);

--- a/src/app/journal/journal.module.ts
+++ b/src/app/journal/journal.module.ts
@@ -23,7 +23,7 @@ const journalRoutes: Routes = [
   {
     path: 'post/:slug',
     component: PostSingleComponent,
-    data: { sectionId: sectionId }
+    data: { sectionId: sectionId + 0.1 }
   },
   {
     path: 'tag/:tag/page/:page',


### PR DESCRIPTION
Improves minor visuals:
- Going from post list to single post has a route transition.
- Sticky header content has been reverted to the same width as the page content.